### PR TITLE
Fix warnings about Copy. Silence warnings about unstable.

### DIFF
--- a/lib/rs/src/lib.rs
+++ b/lib/rs/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(unstable)]
+
 pub use protocol::Protocol;
 pub use transport::Transport;
 

--- a/lib/rs/src/protocol/binary_protocol/mod.rs
+++ b/lib/rs/src/protocol/binary_protocol/mod.rs
@@ -5,6 +5,7 @@ use std::num::FromPrimitive;
 
 static BINARY_PROTOCOL_VERSION_1: u16 = 0x8001;
 
+#[derive(Copy)]
 pub struct BinaryProtocol;
 
 impl BinaryProtocol {

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -2,7 +2,7 @@ use transport::Transport;
 
 pub mod binary_protocol;
 
-#[derive(Eq, PartialEq, FromPrimitive, Show)]
+#[derive(Copy, Eq, PartialEq, FromPrimitive, Show)]
 pub enum Type {
     TStop = 0x00,
     TVoid = 0x01,
@@ -19,7 +19,7 @@ pub enum Type {
     TList = 0x0f
 }
 
-#[derive(Eq, PartialEq, FromPrimitive, Show)]
+#[derive(Copy, Eq, PartialEq, FromPrimitive, Show)]
 pub enum MessageType {
     MtCall = 0x01,
     MtReply = 0x02,


### PR DESCRIPTION
This fixes warnings for rust nightly 2014-01-14.