### PR TITLE
Remove panics from protocol

### DIFF
--- a/lib/rs/src/lib.rs
+++ b/lib/rs/src/lib.rs
@@ -6,3 +6,18 @@ pub use transport::Transport;
 
 pub mod protocol;
 pub mod transport;
+
+#[derive(Eq, PartialEq, Show)]
+pub enum ThriftErr {
+    TransportError(std::io::IoError),
+    UnknownProtocol,
+    InvalidData,
+    NegativeSize,
+    SizeLimit,
+    BadVersion,
+    NotImplemented,
+    DepthLimit,
+    InvalidUtf8(std::str::Utf8Error),
+}
+
+pub type TResult<T> = Result<T, ThriftErr>;

--- a/lib/rs/src/protocol/binary_protocol/mod.rs
+++ b/lib/rs/src/protocol/binary_protocol/mod.rs
@@ -1,7 +1,8 @@
-
 use protocol;
 use protocol::{ MessageType, Protocol, Type };
 use transport::Transport;
+use ThriftErr;
+use TResult;
 use std::num::FromPrimitive;
 
 static BINARY_PROTOCOL_VERSION_1: u16 = 0x8001;
@@ -14,11 +15,11 @@ impl BinaryProtocol {
         self.write_byte(transport, type_ as i8);
     }
 
-    fn read_type(&self, transport: &mut Transport) -> Type {
-        let raw = self.read_byte(transport);
+    fn read_type(&self, transport: &mut Transport) -> TResult<Type> {
+        let raw = try!(self.read_byte(transport));
         match FromPrimitive::from_i8(raw) {
-            Some(type_) => type_,
-            None => panic!("unknown type {}", raw),
+            Some(type_) => Ok(type_),
+            None => Err(ThriftErr::InvalidData),
         }
     }
 }
@@ -131,148 +132,163 @@ impl Protocol for BinaryProtocol {
         }
     }
 
-    fn read_message_begin(&self, transport: &mut Transport) -> (String, MessageType, i32) {
-        let header = self.read_i32(transport);
+    fn read_message_begin(&self, transport: &mut Transport) -> TResult<(String, MessageType, i32)> {
+        let header = try!(self.read_i32(transport));
         let version = (header >> 16) as u16;
         if version != BINARY_PROTOCOL_VERSION_1 {
-            panic!("unknown protocol version: {:x}", version);
+            return Err(ThriftErr::BadVersion);
         };
-        let name = self.read_string(transport);
+        let name = try!(self.read_string(transport));
         let raw_type = header & 0xff;
         let message_type = match FromPrimitive::from_i32(raw_type) {
             Some(t) => t,
-            None => panic!("unknown message type {:x}", raw_type),
+            None => return Err(ThriftErr::InvalidData),
         };
-        let sequence_id = self.read_i32(transport);
-        (name, message_type, sequence_id)
+        let sequence_id = try!(self.read_i32(transport));
+        Ok((name, message_type, sequence_id))
     }
 
-    fn read_message_end(&self, _transport: &mut Transport) { }
+    fn read_message_end(&self, _transport: &mut Transport) -> TResult<()> {
+        Ok(())
+    }
 
-    fn read_struct_begin(&self, _transport: &mut Transport) -> String { String::from_str("") }
+    fn read_struct_begin(&self, _transport: &mut Transport) -> TResult<String> {
+        Ok(String::new())
+    }
 
-    fn read_struct_end(&self, _transport: &mut Transport) { }
+    fn read_struct_end(&self, _transport: &mut Transport) -> TResult<()> {
+        Ok(())
+    }
 
-    fn read_field_begin(&self, transport: &mut Transport) -> (String, Type, i16) {
-        let field_type = self.read_type(transport);
+    fn read_field_begin(&self, transport: &mut Transport) -> TResult<(String, Type, i16)> {
+        let field_type = try!(self.read_type(transport));
         let field_id = match field_type {
             protocol::Type::TStop => 0,
-            _ => self.read_i16(transport),
+            _ => try!(self.read_i16(transport)),
         };
-        (String::from_str(""), field_type, field_id)
+        Ok((String::new(), field_type, field_id))
     }
 
-    fn read_field_end(&self, _transport: &mut Transport) { }
-
-    fn read_map_begin(&self, transport: &mut Transport) -> (Type, Type, i32) {
-        let key_type = self.read_type(transport);
-        let value_type = self.read_type(transport);
-        let size = self.read_i32(transport);
-        (key_type, value_type, size)
+    fn read_field_end(&self, _transport: &mut Transport) -> TResult<()> {
+        Ok(())
     }
 
-    fn read_map_end(&self, _transport: &mut Transport) { }
-
-    fn read_list_begin(&self, transport: &mut Transport) -> (Type, i32) {
-        let elem_type = self.read_type(transport);
-        let size = self.read_i32(transport);
-        (elem_type, size)
+    fn read_map_begin(&self, transport: &mut Transport) -> TResult<(Type, Type, i32)> {
+        let key_type = try!(self.read_type(transport));
+        let value_type = try!(self.read_type(transport));
+        let size = try!(self.read_i32(transport));
+        Ok((key_type, value_type, size))
     }
 
-    fn read_list_end(&self, _transport: &mut Transport) { }
-
-    fn read_set_begin(&self, transport: &mut Transport) -> (Type, i32) {
-        let elem_type = self.read_type(transport);
-        let size = self.read_i32(transport);
-        (elem_type, size)
+    fn read_map_end(&self, _transport: &mut Transport) -> TResult<()> {
+        Ok(())
     }
 
-    fn read_set_end(&self, _transport: &mut Transport) { }
+    fn read_list_begin(&self, transport: &mut Transport) -> TResult<(Type, i32)> {
+        let elem_type = try!(self.read_type(transport));
+        let size = try!(self.read_i32(transport));
+        Ok((elem_type, size))
+    }
 
-    fn read_bool(&self, transport: &mut Transport) -> bool {
-        match self.read_byte(transport) {
-            0 => false,
-            _ => true,
+    fn read_list_end(&self, _transport: &mut Transport) -> TResult<()> {
+        Ok(())
+    }
+
+    fn read_set_begin(&self, transport: &mut Transport) -> TResult<(Type, i32)> {
+        let elem_type = try!(self.read_type(transport));
+        let size = try!(self.read_i32(transport));
+        Ok((elem_type, size))
+    }
+
+    fn read_set_end(&self, _transport: &mut Transport) -> TResult<()> {
+        Ok(())
+    }
+
+    fn read_bool(&self, transport: &mut Transport) -> TResult<bool> {
+        match try!(self.read_byte(transport)) {
+            0 => Ok(false),
+            _ => Ok(true),
         }
     }
 
-    fn read_byte(&self, transport: &mut Transport) -> i8 {
-        transport.read_i8().unwrap()
+    fn read_byte(&self, transport: &mut Transport) -> TResult<i8> {
+        transport.read_i8().map_err(|e| ThriftErr::TransportError(e))
     }
 
-    fn read_i16(&self, transport: &mut Transport) -> i16 {
-        transport.read_be_i16().unwrap()
+    fn read_i16(&self, transport: &mut Transport) -> TResult<i16> {
+        transport.read_be_i16().map_err(|e| ThriftErr::TransportError(e))
     }
 
-    fn read_i32(&self, transport: &mut Transport) -> i32 {
-        transport.read_be_i32().unwrap()
+    fn read_i32(&self, transport: &mut Transport) -> TResult<i32> {
+        transport.read_be_i32().map_err(|e| ThriftErr::TransportError(e))
     }
 
-    fn read_i64(&self, transport: &mut Transport) -> i64 {
-        transport.read_be_i64().unwrap()
+    fn read_i64(&self, transport: &mut Transport) -> TResult<i64> {
+        transport.read_be_i64().map_err(|e| ThriftErr::TransportError(e))
     }
 
-    fn read_double(&self, transport: &mut Transport) -> f64 {
-        transport.read_be_f64().unwrap()
+    fn read_double(&self, transport: &mut Transport) -> TResult<f64> {
+        transport.read_be_f64().map_err(|e| ThriftErr::TransportError(e))
     }
 
-    fn read_string(&self, transport: &mut Transport) -> String {
-        String::from_utf8(self.read_binary(transport)).unwrap()
+    fn read_string(&self, transport: &mut Transport) -> TResult<String> {
+        let bytes = try!(self.read_binary(transport));
+        String::from_utf8(bytes).map_err(|e| ThriftErr::InvalidUtf8(e.utf8_error()))
     }
 
-    fn read_binary(&self, transport: &mut Transport) -> Vec<u8> {
-        let len = self.read_i32(transport) as usize;
-        transport.read_exact(len).unwrap()
+    fn read_binary(&self, transport: &mut Transport) -> TResult<Vec<u8>> {
+        let len = try!(self.read_i32(transport)) as usize;
+        transport.read_exact(len).map_err(|e| ThriftErr::TransportError(e))
     }
 
-    #[allow(unused_variables)]
-    fn skip(&self, transport: &mut Transport, _type: Type) {
-        match _type {
-            Type::TBool => { self.read_bool(transport); }
-            Type::TByte => { self.read_byte(transport); }
-            Type::TI16 => { self.read_i16(transport); }
-            Type::TI32 => { self.read_i32(transport); }
-            Type::TI64 => { self.read_i64(transport); }
-            Type::TDouble => { self.read_double(transport); }
-            Type::TString => { self.read_binary(transport); }
+    fn skip(&self, transport: &mut Transport, type_: Type) -> TResult<()> {
+        match type_ {
+            Type::TBool => { try!(self.read_bool(transport)); }
+            Type::TByte => { try!(self.read_byte(transport)); }
+            Type::TI16 => { try!(self.read_i16(transport)); }
+            Type::TI32 => { try!(self.read_i32(transport)); }
+            Type::TI64 => { try!(self.read_i64(transport)); }
+            Type::TDouble => { try!(self.read_double(transport)); }
+            Type::TString => { try!(self.read_binary(transport)); }
             Type::TStruct => { 
-                self.read_struct_begin(transport);
+                try!(self.read_struct_begin(transport));
                 loop {
-                    let (fname, ftype, fid) = self.read_field_begin(transport);
-                    if ftype == Type::TStop {
+                    let (_, field_type, _) = try!(self.read_field_begin(transport));
+                    if field_type == Type::TStop {
                         break;
                     }
-                    self.skip(transport, ftype);
-                    self.read_field_end(transport);
+                    try!(self.skip(transport, field_type));
+                    try!(self.read_field_end(transport));
                 }
-                self.read_struct_end(transport);
+                try!(self.read_struct_end(transport));
             }
             Type::TMap => {
-                let (key_type, value_type, size) = self.read_map_begin(transport);
-                for i in range(0, size) {
-                    self.skip(transport, key_type);
-                    self.skip(transport, value_type);
+                let (key_type, value_type, size) = try!(self.read_map_begin(transport));
+                for _ in range(0, size) {
+                    try!(self.skip(transport, key_type));
+                    try!(self.skip(transport, value_type));
                 }
-                self.read_map_end(transport);
+                try!(self.read_map_end(transport));
             }
             Type::TSet => {
-                let (elem_type, size) = self.read_set_begin(transport);
-                for i in range(0, size) {
-                    self.skip(transport, elem_type);
+                let (elem_type, size) = try!(self.read_set_begin(transport));
+                for _ in range(0, size) {
+                    try!(self.skip(transport, elem_type));
                 }
-                self.read_set_end(transport);
+                try!(self.read_set_end(transport));
             }
             Type::TList => {
-                let (elem_type, size) = self.read_list_begin(transport);
-                for i in range(0, size) {
-                    self.skip(transport, elem_type);
+                let (elem_type, size) = try!(self.read_list_begin(transport));
+                for _ in range(0, size) {
+                    try!(self.skip(transport, elem_type));
                 }
-                self.read_list_end(transport);
+                try!(self.read_list_end(transport));
             }
-            _ => { }
-        }
+            Type::TVoid => { }
+            Type::TStop => { }
+        };
+        Ok(())
     }
-
 }
 
 #[cfg(test)]

--- a/lib/rs/src/protocol/binary_protocol/test/mod.rs
+++ b/lib/rs/src/protocol/binary_protocol/test/mod.rs
@@ -3,38 +3,39 @@ use super::BinaryProtocol;
 use protocol;
 use protocol::Protocol;
 use transport::test::FakeTransport;
+use ThriftErr;
 
 #[test]
 pub fn read_bool() {
     let transport = &mut FakeTransport::new(vec!(0x00, 0x01, 0xff));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_bool(transport), false);
-    assert_eq!(protocol.read_bool(transport), true);
-    assert_eq!(protocol.read_bool(transport), true);
+    assert_eq!(protocol.read_bool(transport), Ok(false));
+    assert_eq!(protocol.read_bool(transport), Ok(true));
+    assert_eq!(protocol.read_bool(transport), Ok(true));
 }
 
 #[test]
 pub fn read_byte() {
     let transport = &mut FakeTransport::new(vec!(0xa4, 0x27));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_byte(transport), -0x5c);
-    assert_eq!(protocol.read_byte(transport), 0x27);
+    assert_eq!(protocol.read_byte(transport), Ok(-0x5c));
+    assert_eq!(protocol.read_byte(transport), Ok(0x27));
 }
 
 #[test]
 pub fn read_i16() {
     let transport = &mut FakeTransport::new(vec!(0xf2, 0xf8, 0xa1, 0x40));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_i16(transport), -0x0d08);
-    assert_eq!(protocol.read_i16(transport), -0x5ec0);
+    assert_eq!(protocol.read_i16(transport), Ok(-0x0d08));
+    assert_eq!(protocol.read_i16(transport), Ok(-0x5ec0));
 }
 
 #[test]
 pub fn read_i32() {
     let transport = &mut FakeTransport::new(vec!(0x27, 0xd0, 0x39, 0x49, 0xe5, 0xd8, 0xfe, 0x8b));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_i32(transport), 0x27d03949);
-    assert_eq!(protocol.read_i32(transport), -0x1a270175);
+    assert_eq!(protocol.read_i32(transport), Ok(0x27d03949));
+    assert_eq!(protocol.read_i32(transport), Ok(-0x1a270175));
 }
 
 #[test]
@@ -44,8 +45,8 @@ pub fn read_i64() {
         0xa7, 0x2e, 0x82, 0xea, 0xd1, 0x28, 0x0b, 0xe2,
     ));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_i64(transport), 0x27d03949e5d8fe8b);
-    assert_eq!(protocol.read_i64(transport), -0x58d17d152ed7f41e);
+    assert_eq!(protocol.read_i64(transport), Ok(0x27d03949e5d8fe8b));
+    assert_eq!(protocol.read_i64(transport), Ok(-0x58d17d152ed7f41e));
 }
 
 #[test]
@@ -55,8 +56,8 @@ pub fn read_double() {
         0xbf, 0xe9, 0x3a, 0xe4, 0x21, 0xd3, 0x0e, 0x85,
     ));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_double(transport), 3247.342234);
-    assert_eq!(protocol.read_double(transport), -0.78843886);
+    assert_eq!(protocol.read_double(transport), Ok(3247.342234));
+    assert_eq!(protocol.read_double(transport), Ok(-0.78843886));
 }
 
 #[test]
@@ -67,9 +68,9 @@ pub fn read_string() {
         0x00, 0x00, 0x00, 0x0d, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21,
     ));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_string(transport), String::from_str(""));
-    assert_eq!(protocol.read_string(transport), String::from_str("Asdf"));
-    assert_eq!(protocol.read_string(transport), String::from_str("Hello, World!"));
+    assert_eq!(protocol.read_string(transport), Ok(String::from_str("")));
+    assert_eq!(protocol.read_string(transport), Ok(String::from_str("Asdf")));
+    assert_eq!(protocol.read_string(transport), Ok(String::from_str("Hello, World!")));
 }
 
 #[test]
@@ -80,38 +81,53 @@ pub fn read_binary() {
         0x00, 0x00, 0x00, 0x0d, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21,
     ));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_binary(transport), vec!());
-    assert_eq!(protocol.read_binary(transport), vec!(0x41, 0x73, 0x64, 0x66));
-    assert_eq!(protocol.read_binary(transport), vec!(0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21));
+    assert_eq!(protocol.read_binary(transport), Ok(vec!()));
+    assert_eq!(protocol.read_binary(transport), Ok(vec!(0x41, 0x73, 0x64, 0x66)));
+    assert_eq!(protocol.read_binary(transport), Ok(vec!(0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21)));
 }
 
 #[test]
 pub fn read_set_begin() {
     let transport = &mut FakeTransport::new(vec!(0x0b, 0x00, 0x00, 0x01, 0x0f));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_set_begin(transport), (protocol::Type::TString, 0x0000010f));
+    assert_eq!(
+        protocol.read_set_begin(transport),
+        Ok((protocol::Type::TString, 0x0000010f))
+    );
 }
 
 #[test]
 pub fn read_list_begin() {
     let transport = &mut FakeTransport::new(vec!(0x0b, 0x00, 0x00, 0x01, 0x0f));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_list_begin(transport), (protocol::Type::TString, 0x0000010f));
+    assert_eq!(
+        protocol.read_list_begin(transport),
+        Ok((protocol::Type::TString, 0x0000010f))
+    );
 }
 
 #[test]
 pub fn read_map_begin() {
     let transport = &mut FakeTransport::new(vec!(0x0b, 0x08, 0x00, 0x00, 0x01, 0x0f));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_map_begin(transport), (protocol::Type::TString, protocol::Type::TI32, 0x0000010f));
+    assert_eq!(
+        protocol.read_map_begin(transport),
+        Ok((protocol::Type::TString, protocol::Type::TI32, 0x0000010f))
+    );
 }
 
 #[test]
 pub fn read_field_begin() {
     let transport = &mut FakeTransport::new(vec!(0x00, 0x0d, 0x14, 0x0e));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_field_begin(transport), (String::from_str(""), protocol::Type::TStop, 0));
-    assert_eq!(protocol.read_field_begin(transport), (String::from_str(""), protocol::Type::TMap, 0x140e));
+    assert_eq!(
+        protocol.read_field_begin(transport),
+        Ok((String::from_str(""), protocol::Type::TStop, 0))
+    );
+    assert_eq!(
+        protocol.read_field_begin(transport),
+        Ok((String::from_str(""), protocol::Type::TMap, 0x140e))
+  );
 }
 
 #[test]
@@ -122,5 +138,36 @@ pub fn read_message_begin() {
         0x00, 0x02, 0x47, 0x1e
     ));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_message_begin(transport), (String::from_str("foo"), protocol::MessageType::MtCall, 0x0002471e));
+    assert_eq!(
+        protocol.read_message_begin(transport),
+        Ok((String::from_str("foo"), protocol::MessageType::MtCall, 0x0002471e))
+    );
+}
+
+#[test]
+pub fn read_message_begin_bad_version() {
+    let transport = &mut FakeTransport::new(vec!(
+        0x80, 0x22, 0x00, 0x01,
+        0x00, 0x00, 0x00, 0x03, 0x66, 0x6f, 0x6f,
+        0x00, 0x02, 0x47, 0x1e
+    ));
+    let protocol = BinaryProtocol;
+    assert_eq!(
+        protocol.read_message_begin(transport),
+        Err(ThriftErr::BadVersion)
+    );
+}
+
+#[test]
+pub fn read_message_begin_invalid_message_type() {
+    let transport = &mut FakeTransport::new(vec!(
+        0x80, 0x01, 0x00, 0x0f,
+        0x00, 0x00, 0x00, 0x03, 0x66, 0x6f, 0x6f,
+        0x00, 0x02, 0x47, 0x1e
+    ));
+    let protocol = BinaryProtocol;
+    assert_eq!(
+        protocol.read_message_begin(transport),
+        Err(ThriftErr::InvalidData)
+    );
 }

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -1,4 +1,5 @@
 use transport::Transport;
+use TResult;
 
 pub mod binary_protocol;
 
@@ -73,32 +74,32 @@ pub trait Protocol {
     fn write_string(&self, transport: &mut Transport, value: &str);
     fn write_binary(&self, transport: &mut Transport, value: &[u8]);
 
-    fn read_message_begin(&self, transport: &mut Transport) -> (String, MessageType, i32);
-    fn read_message_end(&self, transport: &mut Transport);
+    fn read_message_begin(&self, transport: &mut Transport) -> TResult<(String, MessageType, i32)>;
+    fn read_message_end(&self, transport: &mut Transport) -> TResult<()>;
 
-    fn read_struct_begin(&self, transport: &mut Transport) -> String;
-    fn read_struct_end(&self, transport: &mut Transport);
+    fn read_struct_begin(&self, transport: &mut Transport) -> TResult<String>;
+    fn read_struct_end(&self, transport: &mut Transport) -> TResult<()>;
 
-    fn read_field_begin(&self, transport: &mut Transport) -> (String, Type, i16);
-    fn read_field_end(&self, transport: &mut Transport);
+    fn read_field_begin(&self, transport: &mut Transport) -> TResult<(String, Type, i16)>;
+    fn read_field_end(&self, transport: &mut Transport) -> TResult<()>;
 
-    fn read_map_begin(&self, transport: &mut Transport) -> (Type, Type, i32);
-    fn read_map_end(&self, transport: &mut Transport);
+    fn read_map_begin(&self, transport: &mut Transport) -> TResult<(Type, Type, i32)>;
+    fn read_map_end(&self, transport: &mut Transport) -> TResult<()>;
 
-    fn read_list_begin(&self, transport: &mut Transport) -> (Type, i32);
-    fn read_list_end(&self, transport: &mut Transport);
+    fn read_list_begin(&self, transport: &mut Transport) -> TResult<(Type, i32)>;
+    fn read_list_end(&self, transport: &mut Transport) -> TResult<()>;
 
-    fn read_set_begin(&self, transport: &mut Transport) -> (Type, i32);
-    fn read_set_end(&self, transport: &mut Transport);
+    fn read_set_begin(&self, transport: &mut Transport) -> TResult<(Type, i32)>;
+    fn read_set_end(&self, transport: &mut Transport) -> TResult<()>;
 
-    fn read_bool(&self, transport: &mut Transport) -> bool;
-    fn read_byte(&self, transport: &mut Transport) -> i8;
-    fn read_i16(&self, transport: &mut Transport) -> i16;
-    fn read_i32(&self, transport: &mut Transport) -> i32;
-    fn read_i64(&self, transport: &mut Transport) -> i64;
-    fn read_double(&self, transport: &mut Transport) -> f64;
-    fn read_string(&self, transport: &mut Transport) -> String;
-    fn read_binary(&self, transport: &mut Transport) -> Vec<u8>;
+    fn read_bool(&self, transport: &mut Transport) -> TResult<bool>;
+    fn read_byte(&self, transport: &mut Transport) -> TResult<i8>;
+    fn read_i16(&self, transport: &mut Transport) -> TResult<i16>;
+    fn read_i32(&self, transport: &mut Transport) -> TResult<i32>;
+    fn read_i64(&self, transport: &mut Transport) -> TResult<i64>;
+    fn read_double(&self, transport: &mut Transport) -> TResult<f64>;
+    fn read_string(&self, transport: &mut Transport) -> TResult<String>;
+    fn read_binary(&self, transport: &mut Transport) -> TResult<Vec<u8>>;
 
-    fn skip(&self, transport: &mut Transport, _type: Type);
+    fn skip(&self, transport: &mut Transport, type_: Type) -> TResult<()>;
 }


### PR DESCRIPTION
As discussed earlier, the error handling on the protocol side has to be improved as user input could cause a `panic!`. This is a work in progress, but I am pleased with the result and, if you agree, I will do the same for the `write_*` functions.