### PR TITLE
Fix compilation and silence warnings for Rust nightly 2015-02-08.

### DIFF
--- a/lib/rs/src/lib.rs
+++ b/lib/rs/src/lib.rs
@@ -1,4 +1,5 @@
-#![allow(unstable)]
+#![feature(core)]
+#![feature(io)]
 #![feature(slicing_syntax)]
 
 pub use protocol::Protocol;
@@ -7,7 +8,7 @@ pub use transport::Transport;
 pub mod protocol;
 pub mod transport;
 
-#[derive(Eq, PartialEq, Show)]
+#[derive(Eq, PartialEq, Debug)]
 pub enum ThriftErr {
     TransportError(std::old_io::IoError),
     UnknownProtocol,

--- a/lib/rs/src/protocol/binary_protocol/mod.rs
+++ b/lib/rs/src/protocol/binary_protocol/mod.rs
@@ -150,12 +150,12 @@ impl Protocol for BinaryProtocol {
     }
 
     fn write_string(&self, transport: &mut Transport, value: &String) -> TResult<()> {
-        self.write_binary(transport, value.as_slice().as_bytes())
+        self.write_binary(transport, (&value[..]).as_bytes())
     }
 
     fn write_binary(&self, transport: &mut Transport, value: &[u8]) -> TResult<()> {
         try!(self.write_i32(transport, value.len() as i32));
-        transport.write(value).map_err(|e| ThriftErr::TransportError(e))
+        transport.write_all(value).map_err(|e| ThriftErr::TransportError(e))
     }
 
     fn read_message_begin(&self, transport: &mut Transport) -> TResult<(String, MessageType, i32)> {
@@ -290,7 +290,7 @@ impl Protocol for BinaryProtocol {
             }
             Type::TMap => {
                 let (key_type, value_type, size) = try!(self.read_map_begin(transport));
-                for _ in range(0, size) {
+                for _ in 0..size {
                     try!(self.skip(transport, key_type));
                     try!(self.skip(transport, value_type));
                 }
@@ -298,14 +298,14 @@ impl Protocol for BinaryProtocol {
             }
             Type::TSet => {
                 let (elem_type, size) = try!(self.read_set_begin(transport));
-                for _ in range(0, size) {
+                for _ in 0..size {
                     try!(self.skip(transport, elem_type));
                 }
                 try!(self.read_set_end(transport));
             }
             Type::TList => {
                 let (elem_type, size) = try!(self.read_list_begin(transport));
-                for _ in range(0, size) {
+                for _ in 0..size {
                     try!(self.skip(transport, elem_type));
                 }
                 try!(self.read_list_end(transport));

--- a/lib/rs/src/protocol/binary_protocol/test/mod.rs
+++ b/lib/rs/src/protocol/binary_protocol/test/mod.rs
@@ -87,9 +87,9 @@ pub fn read_string() {
         0x00, 0x00, 0x00, 0x0d, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21,
     ));
     let protocol = BinaryProtocol;
-    assert_eq!(protocol.read_string(transport), Ok(String::from_str("")));
-    assert_eq!(protocol.read_string(transport), Ok(String::from_str("Asdf")));
-    assert_eq!(protocol.read_string(transport), Ok(String::from_str("Hello, World!")));
+    assert_eq!(protocol.read_string(transport), Ok("".to_string()));
+    assert_eq!(protocol.read_string(transport), Ok("Asdf".to_string()));
+    assert_eq!(protocol.read_string(transport), Ok("Hello, World!".to_string()));
 }
 
 #[test]
@@ -141,11 +141,11 @@ pub fn read_field_begin() {
     let protocol = BinaryProtocol;
     assert_eq!(
         protocol.read_field_begin(transport),
-        Ok((String::from_str(""), protocol::Type::TStop, 0))
+        Ok(("".to_string(), protocol::Type::TStop, 0))
     );
     assert_eq!(
         protocol.read_field_begin(transport),
-        Ok((String::from_str(""), protocol::Type::TMap, 0x140e))
+        Ok(("".to_string(), protocol::Type::TMap, 0x140e))
   );
 }
 
@@ -159,7 +159,7 @@ pub fn read_message_begin() {
     let protocol = BinaryProtocol;
     assert_eq!(
         protocol.read_message_begin(transport),
-        Ok((String::from_str("foo"), protocol::MessageType::MtCall, 0x0002471e))
+        Ok(("foo".to_string(), protocol::MessageType::MtCall, 0x0002471e))
     );
 }
 

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -24,7 +24,7 @@ use ThriftErr;
 
 pub mod binary_protocol;
 
-#[derive(Copy, Eq, PartialEq, FromPrimitive, Show)]
+#[derive(Copy, Eq, PartialEq, FromPrimitive, Debug)]
 pub enum Type {
     TStop = 0x00,
     TVoid = 0x01,
@@ -41,7 +41,7 @@ pub enum Type {
     TList = 0x0f
 }
 
-#[derive(Copy, Eq, PartialEq, FromPrimitive, Show)]
+#[derive(Copy, Eq, PartialEq, FromPrimitive, Debug)]
 pub enum MessageType {
     MtCall = 0x01,
     MtReply = 0x02,
@@ -162,7 +162,6 @@ impl ProtocolHelpers {
         Ok(())
     }
 
-    #[allow(unused_variables)]
     pub fn receive<R: Readable>(protocol: &Protocol, 
                             transport: &mut Transport, 
                             op: &'static str, 
@@ -180,7 +179,7 @@ impl ProtocolHelpers {
                 Err(ThriftErr::Exception)
             }
             (fname, MessageType::MtReply, _) => {
-                if fname.as_slice() == op {
+                if &fname[..] == op {
                     try!(result.read(protocol, transport));
                     try!(protocol.read_message_end(transport));
                     Ok(())

--- a/lib/rs/src/transport/test/fake_transport.rs
+++ b/lib/rs/src/transport/test/fake_transport.rs
@@ -16,8 +16,8 @@ impl FakeTransport {
 }
 
 impl Writer for FakeTransport {
-    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
-        self.writer.write(buf)
+    fn write_all(&mut self, buf: &[u8]) -> IoResult<()> {
+        self.writer.write_all(buf)
     }
 
     fn flush(&mut self) -> IoResult<()> {


### PR DESCRIPTION
It wasn't compiling because `Writer::write` was renamed to `Writer::write_all`. I went head and fixed warnings as well.