### PR TITLE
#36 Use bufstream crate

### DIFF
--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Simon Génier <s@simon.coffee>", "Maxim Golov <maxim.golov@gmail.com
 
 [dependencies]
 podio = "0.1"
-bufstream = "0.1.1"
+bufstream = "0.1"

--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Simon Génier <s@simon.coffee>", "Maxim Golov <maxim.golov@gmail.com
 
 [dependencies]
 podio = "0.1"
+bufstream = "0.1.1"

--- a/lib/rs/src/lib.rs
+++ b/lib/rs/src/lib.rs
@@ -1,6 +1,6 @@
-#![feature(buf_stream)]
 
 extern crate podio;
+extern crate bufstream;
 
 pub use protocol::Protocol;
 pub use protocol::Error;

--- a/lib/rs/src/transport/tcp_transport.rs
+++ b/lib/rs/src/transport/tcp_transport.rs
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-use std::io;
 use std::io::prelude::*;
 use std::net;
+use bufstream;
 
 impl super::Transport for net::TcpStream { }
 
-impl<T: Read + Write> super::Transport for io::BufStream<T> { }
+impl<T: Read + Write> super::Transport for bufstream::BufStream<T> { }

--- a/tutorial/rs/Cargo.toml
+++ b/tutorial/rs/Cargo.toml
@@ -13,5 +13,8 @@ path = "src/client.rs"
 name = "server"
 path = "src/server.rs"
 
+[dependencies]
+bufstream = "0.1.1"
+
 [dependencies.thrift]
 path = "../../lib/rs"

--- a/tutorial/rs/Cargo.toml
+++ b/tutorial/rs/Cargo.toml
@@ -14,7 +14,7 @@ name = "server"
 path = "src/server.rs"
 
 [dependencies]
-bufstream = "0.1.1"
+bufstream = "0.1"
 
 [dependencies.thrift]
 path = "../../lib/rs"

--- a/tutorial/rs/src/client.rs
+++ b/tutorial/rs/src/client.rs
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-#![feature(buf_stream)]
-
 extern crate thrift;
+extern crate bufstream;
 
 use std::str::FromStr;
 use std::net;
-use std::io::BufStream;
+use bufstream::BufStream;
 use thrift::protocol::binary_protocol::BinaryProtocol;
 
 mod tutorial;


### PR DESCRIPTION
It seems to be a good idea to propagate all changes (maybe except for very minor ones) through pull requests, so will appreciate feedback on this one. It is part of #36.

Did a quick performance check of the client and it seems to be 0.125 sec for Rust vs 0.13 for C++, similar to buf_stream.
